### PR TITLE
CS-2049: removing GTM and loggy tracking/new server logging

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,8 +36,7 @@
         "node_modules/angular-translate/dist/angular-translate.js",
         "node_modules/angular-translate/dist/angular-translate-storage-cookie/angular-translate-storage-cookie.js",
         "node_modules/angular-translate/dist/angular-translate-storage-local/angular-translate-storage-local.js",
-        "node_modules/angular-growl-v2/build/angular-growl.js",
-        "node_modules/angular-gtm-logger/angular-gtm-logger.js"
+        "node_modules/angular-growl-v2/build/angular-growl.js"
     ],
 	"styles": [
 	    "node_modules/angular-growl-v2/build/angular-growl.css",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,7 +28,6 @@ module.exports = function(config) {
       './node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js',
       './node_modules/angular-growl-v2/build/*.js',
       './node_modules/angular-ellipses/src/*.js',
-      './node_modules/angular-gtm-logger/*.js',
       './node_modules/mathjs/dist/*.js',
       //'./node_modules/moment/*.js',
       //'./node_modules/moment-timezone/*.js',

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "angular-cookies": "1.5.8",
     "angular-ellipses": "https://github.com/genu/angular-ellipses/archive/0.1.3.tar.gz",
     "angular-growl-v2": "https://github.com/JanStevens/angular-growl-2/archive/0.7.2.tar.gz",
-    "angular-gtm-logger": "http://op:x9W3jZ@dist.quintagroup.com/op/angular-gtm-logger-1.0.2.tgz",
     "angular-mocks": "^1.3.0",
     "angular-timer": "http://op:x9W3jZ@dist.quintagroup.com/op/angular-timer-1.1.6.tgz",
     "angular-translate": "2.15.2",

--- a/src/app/auction.js
+++ b/src/app/auction.js
@@ -5,14 +5,11 @@ var appRequires = [
   'timer',
   'angular-growl',
   'angular-ellipses',
-  'GTMLogger',
 ];
 
 var db = {},
     bidder_id = "0",
-    _LTracker = _LTracker || [],
-    db_url = db_url || (location.protocol + '//' + location.host + '/' + window.db_name ) || "",
-    dataLayer = dataLayer || [];
+    db_url = db_url || (location.protocol + '//' + location.host + '/' + window.db_name ) || "";
 
 
 angular.module('auction', appRequires)
@@ -21,11 +18,3 @@ angular.module('auction', appRequires)
     restart_retries: 10,
     default_lang: 'uk',
     debug: false })
-
-
-function logMSG(MSG)
-{
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.open("POST", '/log', true);
-    xmlHttp.send(JSON.stringify(MSG));
-}

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -1,9 +1,8 @@
 angular.module('auction').config([
-  '$qProvider', '$logProvider', '$httpProvider', 'AuctionConfig', 'growlProvider', 'GTMLoggerProvider',
-  function ($qProvider, $logProvider, $httpProvider, AuctionConfig, growlProvider, GTMLoggerProvider) {
+  '$qProvider', '$logProvider', '$httpProvider', 'AuctionConfig', 'growlProvider', '$provide',
+  function ($qProvider, $logProvider, $httpProvider, AuctionConfig, growlProvider, $provide) {
   $httpProvider.defaults.withCredentials = true;
   $qProvider.errorOnUnhandledRejections(false);
-  GTMLoggerProvider.level('INFO').includeTimestamp( true );
   $logProvider.debugEnabled(AuctionConfig.debug); // default is true
   growlProvider.globalTimeToLive({
     success: 4000,
@@ -13,4 +12,52 @@ angular.module('auction').config([
   });
   growlProvider.globalPosition('top-center');
   growlProvider.onlyUniqueMessages(false);
+
+  $provide.decorator('$log', [
+    '$delegate', '$injector',
+    function $logDecorator($delegate, $injector) {
+      $delegate.context = {};
+
+      var originalDebug = $delegate.debug;
+      $delegate.debug = function decoratedDebug(msg) {
+        if(AuctionConfig.debug){
+          var sendLog = $injector.get('sendLog');
+          sendLog(msg, "DEBUG", $delegate.context);
+        }
+        originalDebug.apply($delegate, arguments);
+      };
+
+      var originalInfo = $delegate.info;
+      $delegate.info = function decoratedInfo(msg) {
+        var sendLog = $injector.get('sendLog');
+        sendLog(msg, "INFO", $delegate.context);
+        originalInfo.apply($delegate, arguments);
+      };
+      $delegate.info.logs = originalInfo.logs;  // angular-mocks attribute
+
+      var originalLog = $delegate.log;
+      $delegate.log = function decoratedLog(msg) {
+        var sendLog = $injector.get('sendLog');
+        sendLog(msg, "INFO", $delegate.context);
+        originalLog.apply($delegate, arguments);
+      };
+
+      var originalWarn = $delegate.warn;
+      $delegate.warn = function decoratedWarn(msg) {
+        var sendLog = $injector.get('sendLog');
+        sendLog(msg, "WARNING", $delegate.context);
+        originalWarn.apply($delegate, arguments);
+      };
+
+      var originalError = $delegate.error;
+      $delegate.error = function decoratedError(msg) {
+        var sendLog = $injector.get('sendLog');
+        sendLog(msg, "ERROR", $delegate.context);
+        originalError.apply($delegate, arguments);
+      };
+
+      return $delegate;
+    }
+  ]);
+
 }]);

--- a/src/app/controllers/AuctionCtl.js
+++ b/src/app/controllers/AuctionCtl.js
@@ -30,10 +30,6 @@ angular.module('auction').controller('AuctionController',[
     $rootScope.default_http_error_timeout = 500;
     $rootScope.http_error_timeout = $rootScope.default_http_error_timeout;
     $rootScope.browser_client_id = AuctionUtils.generateUUID();
-    $rootScope.$watch(function() {return $cookies.logglytrackingsession; },
-    function(newValue, oldValue) {
-      $rootScope.browser_session_id = $cookies.logglytrackingsession;
-    });
     window.onunload = function () {
       $log.info("Close window")
       if($rootScope.changes){
@@ -43,15 +39,13 @@ angular.module('auction').controller('AuctionController',[
         $rootScope.evtSrc.close();
       }
     }
+
     if (AuctionConfig.auction_doc_id.indexOf("_") > 0 ){
-      dataLayer.push({
-        "tenderId": AuctionConfig.auction_doc_id.split("_")[0],
-        "lotId": AuctionConfig.auction_doc_id.split("_")[1]
-      });
+      var doc_id_parts =  AuctionConfig.auction_doc_id.split("_")
+      $log.context["TENDER_ID"] = doc_id_parts[0];
+      $log.context["LOT_ID"] = doc_id_parts[1];
     } else {
-      dataLayer.push({
-        "tenderId": AuctionConfig.auction_doc_id
-      });
+      $log.context["TENDER_ID"] = AuctionConfig.auction_doc_id;
     }
     $log.info({
       message: "Start session",

--- a/src/app/factories/SendLog.js
+++ b/src/app/factories/SendLog.js
@@ -1,0 +1,31 @@
+angular.module('auction').factory('sendLog', ['$http', function($http) {
+    return function(msg, level, context) {
+        var context = context || {};
+        // update global context
+        if(angular.isObject(msg) && !angular.isArray(msg)){
+            angular.forEach(msg, function(value, key) {
+                context[key.toUpperCase()] = value;
+            });
+        }
+        // it's important to make a copy, cos the global object may be changed before request is sent
+        var entry = angular.copy(context);
+        entry["LEVEL"] = level;
+        entry["BROWSER_CLIENT_TIMESTAMP"] = (new Date()).toISOString();
+
+        // getting message
+        if(angular.isString(msg)){
+            entry["MESSAGE"] = msg;
+        }else if(angular.isObject(msg) && angular.isDefined(msg.message)){
+            entry["MESSAGE"] = msg.message;
+        }else{
+            entry["MESSAGE"] = msg.toString();
+        }
+        // getting error stack trace
+        if(angular.isObject(msg)){
+          if(angular.isDefined(msg.stack)){
+            entry["STACK"] = msg.stack;
+          }
+        }
+        $http.post('/log', entry);
+    };
+}]);

--- a/src/app/tests/send_log.spec.js
+++ b/src/app/tests/send_log.spec.js
@@ -1,0 +1,80 @@
+describe('sendLog', function() {
+  var $httpBackend, sendLog;
+
+  beforeEach(module('auction'));
+  beforeEach(inject(function(_$httpBackend_, _sendLog_) {
+     $httpBackend = _$httpBackend_;
+     sendLog = _sendLog_;
+  }));
+
+  it('should send log', function() {
+    $httpBackend.expectPOST(
+        '/log',
+        function(data) {
+            data = JSON.parse(data);
+            expect(data["MESSAGE"]).toBe("Hello, world!");
+            expect(data["LEVEL"]).toBe("INFO");
+            expect(data["ADDITIONALLY"]).toBe("Bye!");
+            expect(data["BROWSER_CLIENT_TIMESTAMP"]).toBeDefined();
+            return true
+         }
+    ).respond(200);
+    sendLog("Hello, world!", "INFO", {"ADDITIONALLY": "Bye!"});
+    expect($httpBackend.flush).not.toThrow();
+  });
+
+  it('should send log from exception', function() {
+    var error = new Error("Unexpected something");
+    error.stack = "...";
+    $httpBackend.expectPOST(
+        '/log',
+        function(data) {
+            data = JSON.parse(data);
+            expect(data["MESSAGE"]).toBe("Unexpected something");
+            expect(data["STACK"]).toBe("...");
+            expect(data["LEVEL"]).toBe("ERROR");
+            expect(data["BROWSER_CLIENT_TIMESTAMP"]).toBeDefined();
+            return true
+         }
+    ).respond(200);
+    sendLog(error, "ERROR");
+    expect($httpBackend.flush).not.toThrow();
+  });
+
+  it('should send log object', function() {
+    $httpBackend.expectPOST(
+        '/log',
+        function(data) {
+            data = JSON.parse(data);
+            expect(data["MESSAGE"]).toBe("Hi");
+            expect(data["ADD"]).toBe("THIS");
+            expect(data["LEVEL"]).toBe("INFO");
+            expect(data["BROWSER_CLIENT_TIMESTAMP"]).toBeDefined();
+            return true
+         }
+    ).respond(200);
+    sendLog({"message": "Hi", "ADD": "THIS"}, "INFO");
+    expect($httpBackend.flush).not.toThrow();
+  });
+
+  it('should send log object to string', function() {
+    $httpBackend.expectPOST(
+        '/log',
+        function(data) {
+            data = JSON.parse(data);
+            expect(data["MESSAGE"]).toBe("1,2");
+            expect(data["LEVEL"]).toBe("INFO");
+            expect(data["BROWSER_CLIENT_TIMESTAMP"]).toBeDefined();
+            return true
+         }
+    ).respond(200);
+    sendLog([1, 2], "INFO");
+    expect($httpBackend.flush).not.toThrow();
+  });
+
+  afterEach(function() {
+     $httpBackend.verifyNoOutstandingExpectation();
+     $httpBackend.verifyNoOutstandingRequest();
+  });
+
+});

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -9,16 +9,6 @@
     {% include "base/images.html" %}
     <meta name="msapplication-TileColor" content="#9aba13">
     <meta name="msapplication-TileImage" content="mstile-144x144.png">
-
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5QJXWB"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5QJXWB');</script>
-    <!-- End Google Tag Manager -->
     {% block head %} {% endblock %}
 </head>
 {% block body %} {% endblock %}

--- a/templates/tender.html
+++ b/templates/tender.html
@@ -486,7 +486,7 @@
 
             <li class="list-group-item">
                 <p>Browser ID:<span >{{browser_client_id}}</span></p>
-                <p>Session ID:<span >{{browser_session_id}}</span></p>
+                <p>Client ID:<span >{{client_id}}</span></p>
             </li>
 
               <li ng-if="form.bid" class="list-group-item">


### PR DESCRIPTION
Что убрал
- гугл тэг из базового темплейта
- GTMLogger  // это квинтовский декоратор, чтоб слать логи в  GTM
- window.dataLayer = window.dataLayer || [];  // это гугл тег менеджера приблуда
- logMSG  // вызывается уже из GTM
- browser_session_id  // обновлялось из ид logglytracking , вместо этого на UI вывел client_id (храниться в сессии)

Чё добавил 
- декоратор для $log, чтоб слал логи + некоторые переменные контекста на POST /logs
- логирование необработанных ошибок // уже сделано в ангуляре - по дефолту делает $log.error(exc), а с нашим декоратором еще и шлет на сервер


https://github.com/ProzorroUKR/openprocurement.auction.esco-js/pull/1